### PR TITLE
Update CharacteristicUtils.js

### DIFF
--- a/lib/utils/CharacteristicUtils.js
+++ b/lib/utils/CharacteristicUtils.js
@@ -21,6 +21,7 @@ module.exports = function(node) {
 
                 if (characteristic && characteristicProperties[key]) {
                     characteristic.setProps(characteristicProperties[key]);
+                    characteristic.setValue(characteristicProperties[key]);
                 }
             }
         }
@@ -39,7 +40,7 @@ module.exports = function(node) {
             const cKey = characteristic.displayName
                 .replace(/ /g, "")
                 .replace(/\./g, "_");
-            if (characteristic.props.perms.indexOf("pw") > -1) {
+            if (characteristic.props.perms.indexOf("pr") > -1) {
                 supported.read.push(cKey);
 
                 // Subscribe to 'get' event of readable characteristic
@@ -52,10 +53,7 @@ module.exports = function(node) {
                 });
             }
 
-            if (
-                characteristic.props.perms.indexOf("pr") +
-                characteristic.props.perms.indexOf("ev") >
-                -2
+            if (characteristic.props.perms.indexOf("pw") > -1
             ) {
                 supported.write.push(cKey);
                 


### PR DESCRIPTION
This one handle two change. One correcting characteristic permission handler. Another to enable init (or persistent for pv only) value from Characteristic Properties. 

The handling of characteristic permission may wrongly. Propose to do follow:
1. If PERM.READ (i.e. pv or PAIRED-READ) available, enable "get" event
2. If PERM.WRITE (i.e. pw or PAIRED-WRITE) available, enable "set" event
Remark: No consider PERM.NOTIFY (i.e. ev or EVENT), not necessary for this node emulation.

Some characteristic are read only, like Characteristic.Manufacturer, Characteristic.Identifier etc.
These characteristic should init when the node created.

Here is the example.
<img width="945" alt="Screenshot 2019-04-06 at 9 49 55 AM" src="https://user-images.githubusercontent.com/26063869/55663508-6153fc00-5851-11e9-9ecd-c341437d057f.png">
[flows.json.txt](https://github.com/MyOzCam/node-red-contrib-homekit-bridged/files/3050059/flows.json.txt)
